### PR TITLE
Report total duration statement and normalize log output

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ By default, pg_sampletolog is disabled, you have to change theses settings (defa
 
 pg_sampelog will log arround 10% of statements. It will do computation for each statement by calling `random()` function whose cost is negligible. Message output will look like (depending of your `log_line_prefix`) :
 ```
-2019-01-27 12:50:39.361 CET [27047] LOG:  Sampled query duration: 0.014 ms - SELECT 1;
+2019-01-27 12:50:39.361 CET [27047] LOG:  duration: 0.014 ms  statement: SELECT 1;
 ```
 
   * Log only 10% of transactions: `pg_sampletolog.transaction_sample_rate = 0.1`
@@ -79,8 +79,8 @@ Message output will look like (depending of your `log_line_prefix`) :
 ```
 Transaction : BEGIN; SELECT 1; SELECT 1; COMMIT;
 
-2019-01-27 12:51:40.562 CET [27069] LOG:  Sampled transaction duration: 0.008 ms - SELECT 1;
-2019-01-27 12:51:40.562 CET [27069] LOG:  Sampled transaction duration: 0.005 ms - SELECT 1;
+2019-01-27 12:51:40.562 CET [27069] LOG:  duration: 0.008 ms  statement: SELECT 1;
+2019-01-27 12:51:40.562 CET [27069] LOG:  duration: 0.005 ms  statement: SELECT 1;
 ```
 
   * Log all DDL statements: `pg_sampletolog.log_statement = 'ddl'`:
@@ -88,7 +88,7 @@ Transaction : BEGIN; SELECT 1; SELECT 1; COMMIT;
 pg_sampletolog will log **all** DDL statements, it is similar to `log_statement = ddl` parameter in Postgres. It could be useful if you want a sample of read queries but catch all ddl changes.
 
 ```
-2019-01-27 12:53:47.564 CET [27103] LOG:  Sampled ddl CREATE TABLE t1(c1 int);
+2019-01-27 12:53:47.564 CET [27103] LOG:  statement: CREATE TABLE t1(c1 int);
 ```
 
   * Log all data-modifying statements: `pg_sampletolog.log_statement = 'mod'`:
@@ -96,8 +96,8 @@ pg_sampletolog will log **all** DDL statements, it is similar to `log_statement 
 pg_sampletolog will log **all** data-modifying statements (including ddl), it is similar to `log_statement = mod` parameter in Postgres. It could be useful if you want a sample of read queries but catch all write changes.
 
 ```
-2019-01-27 12:59:54.043 CET [27160] LOG:  Sampled query duration: 0.246 ms - INSERT INTO t1 VALUES(1);
-2019-01-27 13:00:16.468 CET [27160] LOG:  Sampled ddl CREATE INDEX ON t1(c1);
+2019-01-27 12:59:54.043 CET [27160] LOG:  duration: 0.246 ms  statement: INSERT INTO t1 VALUES(1);
+2019-01-27 13:00:16.468 CET [27160] LOG:  duration: 126.851 ms  statement: CREATE INDEX ON t1(c1);
 ```
 
   * Log before execution: `pg_sampletolog.log_before_execution = on`
@@ -145,7 +145,7 @@ We got less than 10% lines of first test because pg_sampletolog don't log `BEGIN
 
 Bonus if you have `pg_stat_statements` installed, pg_sampletolog will report queryid:
 ```
-LOG:  Sampled query duration: 0.032 ms - queryid = 5892081150081336634 - UPDATE pgbench_tellers SET tbalance = tbalance + -3337 WHERE tid = 326;
+LOG:  duration: 0.032 ms  statement: /* queryid = 5892081150081336634 */ UPDATE pgbench_tellers SET tbalance = tbalance + -3337 WHERE tid = 326;
 ```
 
 It is useful to get query's parameters from a query you identified in pg_stat_statements' view.
@@ -176,16 +176,6 @@ test pg_sampletolog               ... ok
  All 1 tests passed. 
 =====================
 ```
-
-## Misc
-
-Regex to remove prefix added by `pg_sampletolog` and replace it by `statement:` (same prefix as log_statement):
-
-
-```
-sed -r 's/Sampled (query|ddl|transaction) - (Duration: [0-9]*\.[0-9]* ms)?( - )?(queryid = -?[0-9]*)?( - )?/statement: /g' inputlog.csv > output.log
-```
-
 
 ## TODO
 

--- a/expected/pg_sampletolog.out
+++ b/expected/pg_sampletolog.out
@@ -1,9 +1,7 @@
 load 'pg_sampletolog';
 set client_min_messages to LOG;
 set pg_sampletolog.disable_log_duration to on;
-LOG:  duration: 0.016 ms  statement: set pg_sampletolog.disable_log_duration to on;
 set pg_sampletolog.statement_sample_rate to 1;
-LOG:  statement: set pg_sampletolog.statement_sample_rate to 1;
 select 1;
 LOG:  statement: select 1;
  ?column? 
@@ -14,7 +12,6 @@ LOG:  statement: select 1;
 set pg_sampletolog.statement_sample_rate to 0;
 LOG:  statement: set pg_sampletolog.statement_sample_rate to 0;
 set pg_sampletolog.transaction_sample_rate to 1;
-LOG:  statement: set pg_sampletolog.transaction_sample_rate to 1;
 select 1;
 LOG:  statement: select 1;
  ?column? 
@@ -55,7 +52,6 @@ LOG:  statement: ROLLBACK;
 set pg_sampletolog.transaction_sample_rate to 0;
 LOG:  statement: set pg_sampletolog.transaction_sample_rate to 0;
 set pg_sampletolog.log_statement = ddl;
-LOG:  statement: set pg_sampletolog.log_statement = ddl;
 create table t1(c1 int);
 LOG:  statement: create table t1(c1 int);
 insert into t1 values (1);

--- a/expected/pg_sampletolog.out
+++ b/expected/pg_sampletolog.out
@@ -1,118 +1,124 @@
 load 'pg_sampletolog';
 set client_min_messages to LOG;
 set pg_sampletolog.disable_log_duration to on;
+LOG:  duration: 0.016 ms  statement: set pg_sampletolog.disable_log_duration to on;
 set pg_sampletolog.statement_sample_rate to 1;
+LOG:  statement: set pg_sampletolog.statement_sample_rate to 1;
 select 1;
-LOG:  Sampled query - select 1;
+LOG:  statement: select 1;
  ?column? 
 ----------
         1
 (1 row)
 
 set pg_sampletolog.statement_sample_rate to 0;
+LOG:  statement: set pg_sampletolog.statement_sample_rate to 0;
 set pg_sampletolog.transaction_sample_rate to 1;
+LOG:  statement: set pg_sampletolog.transaction_sample_rate to 1;
 select 1;
-LOG:  Sampled transaction - select 1;
+LOG:  statement: select 1;
  ?column? 
 ----------
         1
 (1 row)
 
 BEGIN;
-LOG:  Sampled transaction - BEGIN;
+LOG:  statement: BEGIN;
 SELECT 1;
-LOG:  Sampled transaction - SELECT 1;
+LOG:  statement: SELECT 1;
  ?column? 
 ----------
         1
 (1 row)
 
 create table t1(c1 int);
-LOG:  Sampled transaction - create table t1(c1 int);
+LOG:  statement: create table t1(c1 int);
 drop table t1;
-LOG:  Sampled transaction - drop table t1;
+LOG:  statement: drop table t1;
 COMMIT;
-LOG:  Sampled transaction - COMMIT;
+LOG:  statement: COMMIT;
 BEGIN;
-LOG:  Sampled transaction - BEGIN;
+LOG:  statement: BEGIN;
 SELECT 1;
-LOG:  Sampled transaction - SELECT 1;
+LOG:  statement: SELECT 1;
  ?column? 
 ----------
         1
 (1 row)
 
 create table t1(c1 int);
-LOG:  Sampled transaction - create table t1(c1 int);
+LOG:  statement: create table t1(c1 int);
 drop table t1;
-LOG:  Sampled transaction - drop table t1;
+LOG:  statement: drop table t1;
 ROLLBACK;
-LOG:  Sampled transaction - ROLLBACK;
+LOG:  statement: ROLLBACK;
 set pg_sampletolog.transaction_sample_rate to 0;
-LOG:  Sampled transaction - set pg_sampletolog.transaction_sample_rate to 0;
+LOG:  statement: set pg_sampletolog.transaction_sample_rate to 0;
 set pg_sampletolog.log_statement = ddl;
+LOG:  statement: set pg_sampletolog.log_statement = ddl;
 create table t1(c1 int);
-LOG:  Sampled ddl - create table t1(c1 int);
+LOG:  statement: create table t1(c1 int);
 insert into t1 values (1);
 set pg_sampletolog.log_statement = mod;
 insert into t1 values (1);
-LOG:  Sampled query - insert into t1 values (1);
+LOG:  statement: insert into t1 values (1);
 drop table if exists t1;
-LOG:  Sampled ddl - drop table if exists t1;
+LOG:  statement: drop table if exists t1;
 set pg_sampletolog.log_before_execution to on;
 set pg_sampletolog.statement_sample_rate to 1;
 select 1;
-LOG:  Sampled query - select 1;
+LOG:  statement: select 1;
  ?column? 
 ----------
         1
 (1 row)
 
 set pg_sampletolog.statement_sample_rate to 0;
+LOG:  statement: set pg_sampletolog.statement_sample_rate to 0;
 set pg_sampletolog.transaction_sample_rate to 1;
 select 1;
-LOG:  Sampled transaction - select 1;
+LOG:  statement: select 1;
  ?column? 
 ----------
         1
 (1 row)
 
 BEGIN;
-LOG:  Sampled transaction - BEGIN;
+LOG:  statement: BEGIN;
 SELECT 1;
-LOG:  Sampled transaction - SELECT 1;
+LOG:  statement: SELECT 1;
  ?column? 
 ----------
         1
 (1 row)
 
 create table t1(c1 int);
-LOG:  Sampled transaction - create table t1(c1 int);
+LOG:  statement: create table t1(c1 int);
 drop table t1;
-LOG:  Sampled transaction - drop table t1;
+LOG:  statement: drop table t1;
 COMMIT;
-LOG:  Sampled transaction - COMMIT;
+LOG:  statement: COMMIT;
 BEGIN;
-LOG:  Sampled transaction - BEGIN;
+LOG:  statement: BEGIN;
 SELECT 1;
-LOG:  Sampled transaction - SELECT 1;
+LOG:  statement: SELECT 1;
  ?column? 
 ----------
         1
 (1 row)
 
 create table t1(c1 int);
-LOG:  Sampled transaction - create table t1(c1 int);
+LOG:  statement: create table t1(c1 int);
 drop table t1;
-LOG:  Sampled transaction - drop table t1;
+LOG:  statement: drop table t1;
 ROLLBACK;
-LOG:  Sampled transaction - ROLLBACK;
+LOG:  statement: ROLLBACK;
 set pg_sampletolog.transaction_sample_rate to 0;
-LOG:  Sampled transaction - set pg_sampletolog.transaction_sample_rate to 0;
+LOG:  statement: set pg_sampletolog.transaction_sample_rate to 0;
 set pg_sampletolog.log_statement = ddl;
 create table t1(c1 int);
-LOG:  Sampled ddl - create table t1(c1 int);
+LOG:  statement: create table t1(c1 int);
 insert into t1 values (1);
 set pg_sampletolog.log_statement = mod;
 insert into t1 values (1);
-LOG:  Sampled query - insert into t1 values (1);
+LOG:  statement: insert into t1 values (1);

--- a/pg_sampletolog.c
+++ b/pg_sampletolog.c
@@ -261,9 +261,7 @@ pgsl_get_duration(void)
 	int             usecs;
 	int             msecs;
 
-	duration = palloc(sizeof(char) * 32);
-	memset(duration, 0, strlen(duration));
-
+	duration = palloc0(sizeof(char) * 32);
 
 	if (!pgsl_disable_log_duration)
 	{

--- a/pg_sampletolog.c
+++ b/pg_sampletolog.c
@@ -19,11 +19,15 @@
 
 #include "tcop/tcopprot.h"
 #include "tcop/utility.h"
-#include "executor/instrument.h"
 #include "utils/guc.h"
+#include "utils/snapmgr.h"
 #if PG_VERSION_NUM >= 90600
 #include "access/parallel.h"
 #endif
+
+/* to log statement duration */
+#include <utils/timestamp.h>
+#include <access/xact.h>
 
 PG_MODULE_MAGIC;
 
@@ -126,6 +130,7 @@ static void	pgsl_ExecutorEnd(QueryDesc * queryDesc);
 static void	pgsl_log_report(QueryDesc * queryDesc);
 static void	pgsl_check_transaction_issampled(void);
 
+static char   * pgsl_get_duration(void);
 
 /*
  * Module load callback
@@ -248,6 +253,27 @@ _PG_fini(void)
 #endif
 }
 
+static char *
+pgsl_get_duration(void)
+{
+	char		*duration = NULL;
+	long            secs;
+	int             usecs;
+	int             msecs;
+
+	duration = palloc(sizeof(char) * 32);
+	memset(duration, 0, strlen(duration));
+
+
+	if (!pgsl_disable_log_duration)
+	{
+		TimestampDifference(GetCurrentStatementStartTimestamp(), GetCurrentTimestamp(), &secs, &usecs);
+		msecs = usecs / 1000;
+		snprintf(duration, 30, "duration: %ld.%03d ms  ", secs * 1000 + msecs, usecs % 1000);
+	}
+	return duration;
+
+}
 
 void
 pgsl_log_report(QueryDesc * queryDesc)
@@ -256,45 +282,29 @@ pgsl_log_report(QueryDesc * queryDesc)
 	char		message[70];
 
 	/* Log duration and/or queryid if available */
-	if (queryDesc->totaltime != NULL && !pgsl_disable_log_duration) {
-		if (queryDesc->plannedstmt->queryId) {
-			snprintf(message, 70, "- Duration: %.3f ms - queryid = %ld ",
-				 queryDesc->totaltime->total * 1000.0,
+	if (queryDesc->plannedstmt->queryId) {
+		snprintf(message, 70, "%sstatement: /* queryid = %ld */",
+				pgsl_get_duration(),
 #if PG_VERSION_NUM >= 110000
 				 queryDesc->plannedstmt->queryId);
 #else
 				 (uint64) queryDesc->plannedstmt->queryId);
 #endif
-		} else {
-			snprintf(message, 70, "- Duration: %.3f ms ",
-				 queryDesc->totaltime->total * 1000.0);
-		}
-	} else if (queryDesc->plannedstmt->queryId) {
-		snprintf(message, 70, "- queryid = %ld ",
-#if PG_VERSION_NUM >= 110000
-			 queryDesc->plannedstmt->queryId);
-#else
-			 (uint64) queryDesc->plannedstmt->queryId);
-#endif
 	} else {
-		*message = '\0';
+		snprintf(message, 70, "%sstatement:", pgsl_get_duration());
 	}
 
 	/*
 	 * We emit different message depending on whether logging is
 	 * triggered by query sampling or by transaction sampling.
 	 */
-	if (pgsl_query_issampled) {
+	if (pgsl_query_issampled || pgsl_transaction_issampled)
+	{
 		ereport(pgsl_log_level,
-			(errmsg("Sampled query %s- %s",
+			(errmsg("%s %s",
 				message, queryDesc->sourceText),
 			 errhidestmt(true)));
 		pgsl_query_issampled = false;
-	} else if (pgsl_transaction_issampled) {
-		ereport(pgsl_log_level,
-			(errmsg("Sampled transaction %s- %s",
-				message, queryDesc->sourceText),
-			 errhidestmt(true)));
 	}
 }
 
@@ -330,26 +340,31 @@ pgsl_ProcessUtility(
 		    DestReceiver * dest,
 		    char *completionTag)
 {
+#if PG_VERSION_NUM < 100000
+	PlannedStmt *pstmt;
+#endif
 
 	pgsl_check_transaction_issampled();
 
-	if (pgsl_transaction_issampled) {
+	if (pgsl_transaction_issampled)
+	{
 		ereport(pgsl_log_level,
-			(errmsg("Sampled transaction - %s",
-				queryString),
-			 errhidestmt(true)));
-
-	} else {
+				(errmsg("%sstatement: %s", pgsl_get_duration(),
+					queryString),
+				 errhidestmt(true)));
+	}
+	else
+	{
 #if PG_VERSION_NUM >= 100000
-		if (GetCommandLogLevel((Node *) pstmt) <= pgsl_log_statement)
+		if (GetCommandLogLevel((Node *) pstmt) <= pgsl_log_statement || pgsl_stmt_sample_rate == 1)
 #else
-		if (GetCommandLogLevel(parsetree) <= pgsl_log_statement)
+		if (GetCommandLogLevel(parsetree) <= pgsl_log_statement || pgsl_stmt_sample_rate == 1)
 #endif
 		{
 			ereport(pgsl_log_level,
-				(errmsg("Sampled ddl - %s",
-					queryString),
-				 errhidestmt(true)));
+					(errmsg("%sstatement: %s", pgsl_get_duration(),
+						queryString),
+					 errhidestmt(true)));
 		}
 	}
 
@@ -411,22 +426,6 @@ pgsl_ExecutorStart(QueryDesc * queryDesc, int eflags)
 		prev_ExecutorStart(queryDesc, eflags);
 	else
 		standard_ExecutorStart(queryDesc, eflags);
-
-	if (!pgsl_log_before_execution &&
-	    (pgsl_query_issampled || pgsl_transaction_issampled)) {
-		/*
-		 * (From auto_explain) Set up to track total elapsed time in
-		 * ExecutorRun.  Make sure the space is allocated in the
-		 * per-query context so it will go away at ExecutorEnd.
-		 */
-		if (queryDesc->totaltime == NULL) {
-			MemoryContext	oldcxt;
-
-			oldcxt = MemoryContextSwitchTo(queryDesc->estate->es_query_cxt);
-			queryDesc->totaltime = InstrAlloc(1, INSTRUMENT_ALL);
-			MemoryContextSwitchTo(oldcxt);
-		}
-	}
 }
 
 
@@ -501,14 +500,9 @@ pgsl_ExecutorFinish(QueryDesc * queryDesc)
 static void
 pgsl_ExecutorEnd(QueryDesc * queryDesc)
 {
-	if (queryDesc->totaltime && !pgsl_log_before_execution &&
-	    (pgsl_query_issampled || pgsl_transaction_issampled)) {
-		/*
-		 * (From auto_explain) Make sure stats accumulation is done.
-		 * (Note: it's okay if several levels of hook all do this.)
-		 */
-		InstrEndLoop(queryDesc->totaltime);
-
+	if (!pgsl_log_before_execution &&
+			(pgsl_query_issampled || pgsl_transaction_issampled))
+	{
 		pgsl_log_report(queryDesc);
 	}
 	if (prev_ExecutorEnd)


### PR DESCRIPTION
- Fix statement duration that was only the time passed in the executor.
- Make output fully compatible with standard PostgreSQL logs format.
- Move queryId as a comment before the statement to make logs compatible with pgBadger.
- Update test result and documentation.